### PR TITLE
se comenta autodireccionamiento en createPost

### DIFF
--- a/lib/components/post.js
+++ b/lib/components/post.js
@@ -13,7 +13,6 @@ const savePost = (container) => {
   const displayName = petsUser.name;
   const uid = petsUser.uid;
   const photoURL = petsUser.photoURL;
-  console.log(displayName);
   // --------------
   const btnPost = container.querySelector('#postButton');
   btnPost.addEventListener('click', async (event) => {
@@ -30,12 +29,13 @@ const savePost = (container) => {
         .then((imageURL) => addPost(uid, displayName, photoURL, post, ubication, namePet, imageURL))
         .then(() => {
           console.log('imagen cargada ok');
-          window.location.hash = '#/home/profile';
+          // window.location.hash = '#/home/profile';
         });
     } else {
+      console.log('post creado');
       // se crea post sin imagen
       addPost(uid, displayName, photoURL, post, ubication, namePet, '');
-      window.location.hash = '#/home/profile';
+      // window.location.hash = '#/home/profile';
     }
   });
   return container;

--- a/lib/components/profile.js
+++ b/lib/components/profile.js
@@ -78,7 +78,7 @@ const userDocDataInRealTime = (callback) => {
   const user = JSON.parse(localStorage.getItem('user'));
   getUserWithOnSnapshot(user.uid, (doc) => {
     const source = doc.metadata.hasPendingWrites ? 'Local' : 'Server';
-    // console.log(source);
+    console.log(source);
     localStorage.setItem('user', JSON.stringify({ ...user, ...doc.data() }));
     callback(doc.data());
   });


### PR DESCRIPTION
Cuando se direcciona a profile después de crear un post, el observador posts se ejecuta dos veces, lo cual hace que se duplique la vista de los posts, esto sólo pasa con el direccionamiento, cuando se refresca la página se soluciona, falta arreglar esa parte, moviendo un poco las funciones o poniendo una condicional, por ahora está comentado el redireccionamiento desde createPost.